### PR TITLE
Revert "Bump kramdown from 2.2.1 to 2.3.1"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,7 +39,7 @@ GEM
       jekyll (>= 3.3, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
-    kramdown (2.3.1)
+    kramdown (2.2.1)
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
@@ -76,7 +76,6 @@ GEM
     wdm (0.1.1)
 
 PLATFORMS
-  ruby
   x64-mingw32
   x86_64-linux
 


### PR DESCRIPTION
Reverts Null-the-Seagull/saiyanide.github.io#2